### PR TITLE
Updated CMakeLists.txt: Disabled MapLibre GL assertions in Debug. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,11 @@ set(SCWX_VERSION "0.5.4")
 
 option(SCWX_ADDRESS_SANITIZER "Build with Address Sanitizer" OFF)
 
+# Disables MapLibre GL assertions in Debug. Please remove when running Release.
+add_compile_definitions(
+    MBGL_DISABLE_ASSERTIONS
+)
+
 add_subdirectory(external)
 add_subdirectory(wxdata)
 add_subdirectory(scwx-qt)


### PR DESCRIPTION
Please remove when running Release.