### PR TITLE
New layers should be displayed by default on all maps

### DIFF
--- a/scwx-qt/source/scwx/qt/types/layer_types.hpp
+++ b/scwx-qt/source/scwx/qt/types/layer_types.hpp
@@ -63,7 +63,8 @@ struct LayerInfo
    LayerType                    type_ {LayerType::Unknown};
    LayerDescription             description_;
    bool                         movable_ {true};
-   std::array<bool, kMapCount_> displayed_ {true};
+   std::array<bool, kMapCount_> displayed_ {
+      true, true, true, true, true, true, true, true, true};
 };
 
 using LayerVector = boost::container::stable_vector<LayerInfo>;


### PR DESCRIPTION
Inadvertently broken during increase of maps from 4 to 9

