### PR TITLE
Add a "None" map style, default if selected style fails to load

### DIFF
--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -44,6 +44,7 @@
 #include <scwx/util/logger.hpp>
 #include <scwx/util/time.hpp>
 
+#include <algorithm>
 #include <set>
 
 #include <boost/asio/post.hpp>
@@ -858,10 +859,10 @@ void MainWindowImpl::ConfigureMapStyles()
       std::string styleName = mapSettings.map_style(i).GetValue();
 
       if ((customStyleAvailable_ && styleName == "Custom") ||
-          std::find_if(mapProviderInfo.mapStyles_.cbegin(),
-                       mapProviderInfo.mapStyles_.cend(),
-                       [&](const auto& mapStyle)
-                       { return mapStyle.name_ == styleName; }) !=
+          styleName == "None" ||
+          std::ranges::find_if(mapProviderInfo.mapStyles_,
+                               [&](const auto& mapStyle)
+                               { return mapStyle.name_ == styleName; }) !=
              mapProviderInfo.mapStyles_.cend())
       {
          // Initialize map style from settings
@@ -1496,6 +1497,9 @@ void MainWindowImpl::PopulateMapStyles()
       mainWindow_->ui->mapStyleComboBox->addItem(
          QString::fromStdString(mapStyle.name_));
    }
+
+   const std::string kNone = "None";
+   mainWindow_->ui->mapStyleComboBox->addItem(QString::fromStdString(kNone));
 
    auto& generalSettings = settings::GeneralSettings::Instance();
 

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -213,7 +213,9 @@ public:
    std::vector<std::shared_ptr<GenericLayer>> genericLayers_ {};
 
    const std::vector<MapStyle> emptyStyles_ {};
-   std::vector<MapStyle>       customStyles_ {
+   const std::vector<MapStyle> noneStyles_ {
+      MapStyle {.name_ {"None"}, .url_ {}, .drawBelow_ {}}};
+   std::vector<MapStyle> customStyles_ {
       MapStyle {.name_ {"Custom"}, .url_ {}, .drawBelow_ {}}};
    QStringList styleLayers_;
 
@@ -261,6 +263,8 @@ public:
    std::size_t     currentStyleIndex_;
    const MapStyle* currentStyle_;
    std::string     initialStyleName_ {};
+   bool            mapChangedOnce_ {false};
+   bool            mapStylePending_ {false};
 
    Qt::KeyboardModifiers lastKeyboardModifiers_ {
       Qt::KeyboardModifier::NoModifier};
@@ -1128,30 +1132,28 @@ void MapWidget::SetMapStyle(const std::string& styleName)
    const auto& mapProviderInfo = GetMapProviderInfo(mapProvider);
    auto&       fixedStyles     = mapProviderInfo.mapStyles_;
 
-   auto styles = boost::join(fixedStyles,
+   auto styles = boost::join(boost::join(fixedStyles, p->noneStyles_),
                              p->customStyles_[0].IsValid() ? p->customStyles_ :
                                                              p->emptyStyles_);
 
-   if (p->currentStyleIndex_ >= styles.size())
-   {
-      p->currentStyleIndex_ = 0;
-   }
-
    for (size_t i = 0u; i < styles.size(); ++i)
    {
-      if (styles[i].name_ == styleName)
+      const auto* style = &styles[static_cast<std::ptrdiff_t>(i)];
+
+      if (style->name_ == styleName)
       {
-         p->currentStyleIndex_ = i;
-         p->currentStyle_      = &styles[i];
-
-         logger_->debug("Updating style: {}", styles[i].name_);
-
-         util::maplibre::SetMapStyleUrl(p->context_, styles[i].url_);
-
-         if (++p->currentStyleIndex_ >= styles.size())
+         if (p->currentStyleIndex_ == i && p->currentStyle_ == style)
          {
-            p->currentStyleIndex_ = 0;
+            // No need to set the style again
+            break;
          }
+
+         p->currentStyleIndex_ = i;
+         p->currentStyle_      = style;
+
+         logger_->debug("Updating style: {}", style->name_);
+
+         util::maplibre::SetMapStyleUrl(p->context_, style->url_);
 
          break;
       }
@@ -1191,26 +1193,21 @@ void MapWidget::changeStyle()
    const auto& mapProviderInfo = GetMapProviderInfo(mapProvider);
    auto&       fixedStyles     = mapProviderInfo.mapStyles_;
 
-   auto styles = boost::join(fixedStyles,
+   auto styles = boost::join(boost::join(fixedStyles, p->noneStyles_),
                              p->customStyles_[0].IsValid() ? p->customStyles_ :
                                                              p->emptyStyles_);
-
-   if (p->currentStyleIndex_ >= styles.size())
-   {
-      p->currentStyleIndex_ = 0;
-   }
-
-   p->currentStyle_ = &styles[p->currentStyleIndex_];
-
-   logger_->debug("Updating style: {}", styles[p->currentStyleIndex_].name_);
-
-   util::maplibre::SetMapStyleUrl(p->context_,
-                                  styles[p->currentStyleIndex_].url_);
 
    if (++p->currentStyleIndex_ >= styles.size())
    {
       p->currentStyleIndex_ = 0;
    }
+
+   p->currentStyle_ =
+      &styles[static_cast<std::ptrdiff_t>(p->currentStyleIndex_)];
+
+   logger_->debug("Updating style: {}", p->currentStyle_->name_);
+
+   util::maplibre::SetMapStyleUrl(p->context_, p->currentStyle_->url_);
 
    Q_EMIT MapStyleChanged(p->currentStyle_->name_);
 }
@@ -1640,10 +1637,33 @@ void MapWidget::initializeGL()
    else
    {
       SetMapStyle(p->initialStyleName_);
+
+      if (p->initialStyleName_ == "None" || p->initialStyleName_ == "Custom")
+      {
+         // An empty map style may not trigger a map change event, so set the
+         // pending flag to ensure the map style is applied to the map layers
+         p->mapStylePending_ = true;
+      }
    }
 
    connect(
       p->map_.get(), &QMapLibre::Map::mapChanged, this, &MapWidget::mapChanged);
+   connect(p->map_.get(),
+           &QMapLibre::Map::mapLoadingFailed,
+           this,
+           [this](QMapLibre::Map::MapLoadingFailure, const QString& reason)
+           {
+              logger_->error("Map loading failed: {}", reason.toStdString());
+
+              // If the map failed to load, and we haven't loaded a map yet,
+              // default to the "None" map. This prevents a "black screen" on
+              // startup.
+              if (!p->mapChangedOnce_)
+              {
+                 p->mapChangedOnce_ = true;
+                 SetMapStyle("None");
+              }
+           });
 }
 
 void MapWidget::paintGL()
@@ -1847,6 +1867,18 @@ void MapWidget::mapChanged(QMapLibre::Map::MapChange mapChange)
    case QMapLibre::Map::MapChangeDidFinishLoadingStyle:
       p->UpdateLoadedStyle();
       p->AddLayers();
+      p->mapChangedOnce_  = true;
+      p->mapStylePending_ = false;
+      break;
+
+   case QMapLibre::Map::MapChangeDidFinishRenderingFrame:
+      if (p->mapStylePending_)
+      {
+         p->UpdateLoadedStyle();
+         p->AddLayers();
+         p->mapChangedOnce_  = true;
+         p->mapStylePending_ = false;
+      }
       break;
 
    default:

--- a/scwx-qt/source/scwx/qt/util/maplibre.cpp
+++ b/scwx-qt/source/scwx/qt/util/maplibre.cpp
@@ -109,7 +109,7 @@ void SetMapStyleUrl(const std::shared_ptr<map::MapContext>& mapContext,
 
    QString qUrl = QString::fromStdString(url);
 
-   if (mapProvider == map::MapProvider::MapTiler)
+   if (!url.empty() && mapProvider == map::MapProvider::MapTiler)
    {
       qUrl.append("?key=");
       qUrl.append(map::GetMapProviderApiKey(mapProvider));
@@ -118,7 +118,16 @@ void SetMapStyleUrl(const std::shared_ptr<map::MapContext>& mapContext,
    auto map = mapContext->map().lock();
    if (map != nullptr)
    {
-      map->setStyleUrl(qUrl);
+      if (!url.empty())
+      {
+         map->setStyleUrl(qUrl);
+      }
+      else
+      {
+         // If the URL is empty, set a blank style to clear the map
+         map->setStyleJson(
+            R"({"version":8,"name":"blank","sources":{},"layers":[]})");
+      }
    }
 }
 


### PR DESCRIPTION
The radar will now render on a blank map (i.e., no API key, invalid API key). Also adds a "None" selection to the map style dropdown.