### PR TITLE
Sync TorDar with Upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,28 +316,28 @@ jobs:
 
     - name: Upload Artifacts (Windows)
       if: ${{ startsWith(matrix.os, 'windows') }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: supercell-wx-${{ matrix.artifact_suffix }}
         path: ${{ github.workspace }}/supercell-wx/
 
     - name: Upload Debug Artifacts (Windows)
       if: ${{ startsWith(matrix.os, 'windows') }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: supercell-wx-debug-${{ matrix.artifact_suffix }}
         path: ${{ github.workspace }}/build/Release/bin/*.pdb
 
     - name: Upload Artifacts (Linux)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: supercell-wx-${{ matrix.artifact_suffix }}
         path: ${{ github.workspace }}/supercell-wx-${{ matrix.artifact_suffix }}.tar.gz
 
     - name: Upload Debug Artifacts (Linux)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: supercell-wx-debug-${{ matrix.artifact_suffix }}
         path: |
@@ -353,7 +353,7 @@ jobs:
 
     - name: Upload Installer (Windows)
       if: ${{ startsWith(matrix.os, 'windows') }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: supercell-wx-installer-${{ matrix.artifact_suffix }}
         path: ${{ github.workspace }}/build/supercell-wx-*.msi*
@@ -386,7 +386,7 @@ jobs:
 
     - name: Upload AppImage (Linux)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: supercell-wx-appimage-${{ matrix.artifact_suffix }}
         path: ${{ github.workspace }}/*-${{ matrix.appimage_arch }}.AppImage*
@@ -421,7 +421,7 @@ jobs:
 
     - name: Upload FlatPak (Linux)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: supercell-wx-flatpak-${{ matrix.artifact_suffix }}
         path: ${{ github.workspace }}/supercell-wx.flatpak
@@ -435,7 +435,7 @@ jobs:
 
     - name: Upload Disk Image (macOS)
       if: ${{ startsWith(matrix.os, 'macos') }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: supercell-wx-${{ matrix.artifact_suffix }}
         path: ${{ github.workspace }}/build/supercell-wx-*.dmg*
@@ -449,7 +449,7 @@ jobs:
 
     - name: Upload Test Logs
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: supercell-wx-test-logs-${{ matrix.name }}
         path: ${{ github.workspace }}/build/Testing/

--- a/.github/workflows/clang-tidy-comments.yml
+++ b/.github/workflows/clang-tidy-comments.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Post Comments
-        uses: ZedThree/clang-tidy-review/post@v0.23.0
+        uses: ZedThree/clang-tidy-review/post@v0.23.1
         with:
           lgtm_comment_body: ''
           annotations: false

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -154,7 +154,7 @@ jobs:
         rsync -avzh --ignore-missing-args clang_fixes.json ../
 
     - name: Upload Review
-      uses: ZedThree/clang-tidy-review/upload@v0.23.0
+      uses: ZedThree/clang-tidy-review/upload@v0.23.1
 
     - name: Status Check
       if: steps.review.outputs.total_comments > 0

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ import os
 class SupercellWxConan(ConanFile):
     settings   = ("os", "compiler", "build_type", "arch")
     requires   = ("boost/1.89.0",
-                  "cpr/1.14.1",
+                  "cpr/1.14.2",
                   "fontconfig/2.17.1",
                   "geographiclib/2.6",
                   "geos/3.13.0",
@@ -16,7 +16,7 @@ class SupercellWxConan(ConanFile):
                   "libjpeg/9f",
                   "libpng/1.6.54",
                   "libtiff/4.7.1",
-                  "libxml2/2.15.0",
+                  "libxml2/2.15.1",
                   "libzip/1.11.4",
                   "openssl/3.6.0",
                   "range-v3/cci.20240905",


### PR DESCRIPTION
**List of changes:**
- Updated ZedThree/clang-tidy-review action to v0.23.1
-  Updated actions/upload-artifact action to v7 
-  Updated dependency cpr to v1.14.2 
